### PR TITLE
Feat/create album views

### DIFF
--- a/musicApp/albums/forms.py
+++ b/musicApp/albums/forms.py
@@ -7,9 +7,8 @@ class AlbumBaseForm(forms.ModelForm):
         model = Album
         fields = '__all__'
         widgets = {
-            'name': forms.TextInput(attrs={'placeholder': 'Album Name'}),
+            'album_name': forms.TextInput(attrs={'placeholder': 'Album Name'}),
             'artist': forms.TextInput(attrs={'placeholder': 'Artist'}),
-            'genre': forms.TextInput(attrs={'placeholder': 'Genre'}),
             'description': forms.Textarea(attrs={'placeholder': 'Description'}),
             'image_url': forms.URLInput(attrs={'placeholder': 'Image URL'}),
             'price': forms.NumberInput(attrs={'placeholder': 'Price'}),

--- a/musicApp/albums/forms.py
+++ b/musicApp/albums/forms.py
@@ -1,0 +1,33 @@
+from django import forms
+from albums.models import Album
+
+
+class AlbumBaseForm(forms.ModelForm):
+    class Meta:
+        model = Album
+        fields = '__all__'
+        widgets = {
+            'name': forms.TextInput(attrs={'placeholder': 'Album Name'}),
+            'artist': forms.TextInput(attrs={'placeholder': 'Artist'}),
+            'genre': forms.TextInput(attrs={'placeholder': 'Genre'}),
+            'description': forms.Textarea(attrs={'placeholder': 'Description'}),
+            'image_url': forms.URLInput(attrs={'placeholder': 'Image URL'}),
+            'price': forms.NumberInput(attrs={'placeholder': 'Price'}),
+            'owner': forms.HiddenInput(),
+        }
+
+
+class AlbumCreateForm(AlbumBaseForm):
+    ...
+
+
+class AlbumEditForm(AlbumBaseForm):
+    ...
+
+
+class AlbumDeleteForm(AlbumBaseForm):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        for field_name, field in self.fields.items():
+            field.widget.attrs['readonly'] = True
+            field.widget.attrs['disabled'] = True

--- a/musicApp/albums/mixins.py
+++ b/musicApp/albums/mixins.py
@@ -1,0 +1,12 @@
+from profiles.util import get_profile
+
+
+class AttachOwnerMixin:
+    def get_initial(self) -> dict:
+        initial = super().get_initial()
+        initial["owner"] = get_profile()
+        return initial
+
+    def form_valid(self, form):
+        form.instance.owner = get_profile()
+        return super().form_valid(form)

--- a/musicApp/albums/urls.py
+++ b/musicApp/albums/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from albums import views
+
+app_name = 'albums'
+
+urlpatterns = [
+    path('create/', views.AlbumCreateView.as_view(), name='create')
+]

--- a/musicApp/albums/urls.py
+++ b/musicApp/albums/urls.py
@@ -5,5 +5,7 @@ from albums import views
 app_name = 'albums'
 
 urlpatterns = [
-    path('create/', views.AlbumCreateView.as_view(), name='create')
+    path('create/', views.AlbumCreateView.as_view(), name='create'),
+    path('details/<int:pk>/', views.AlbumDetailView.as_view(), name='detail'),
+    path('edit/<int:pk>/', views.AlbumEditView.as_view(), name='edit'),
 ]

--- a/musicApp/albums/urls.py
+++ b/musicApp/albums/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path('create/', views.AlbumCreateView.as_view(), name='create'),
     path('details/<int:pk>/', views.AlbumDetailView.as_view(), name='detail'),
     path('edit/<int:pk>/', views.AlbumEditView.as_view(), name='edit'),
+    path('delete/<int:pk>/', views.AlbumDeleteView.as_view(), name='delete'),
 ]

--- a/musicApp/albums/views.py
+++ b/musicApp/albums/views.py
@@ -1,6 +1,6 @@
 from django.urls import reverse_lazy, reverse
-from django.views.generic import CreateView, DetailView, UpdateView
-from albums.forms import AlbumCreateForm, AlbumEditForm
+from django.views.generic import CreateView, DetailView, UpdateView, DeleteView
+from albums.forms import AlbumCreateForm, AlbumEditForm, AlbumDeleteForm
 from albums.mixins import AttachOwnerMixin
 from albums.models import Album
 from profiles.util import get_profile
@@ -25,3 +25,16 @@ class AlbumEditView(AttachOwnerMixin, UpdateView):
 
     def get_success_url(self) -> str:
         return reverse('albums:detail', kwargs={'pk': self.object.pk})
+
+
+class AlbumDeleteView(DeleteView):
+    model = Album
+    form_class = AlbumDeleteForm
+    template_name = 'albums/album-delete.html'
+    success_url = reverse_lazy("profiles:home")
+
+    def get_initial(self) -> dict:
+        return self.object.__dict__
+
+    def form_invalid(self, form):
+        return super().form_valid(form)

--- a/musicApp/albums/views.py
+++ b/musicApp/albums/views.py
@@ -1,21 +1,27 @@
-from django.urls import reverse_lazy
-from django.views.generic import CreateView
-from albums.forms import AlbumCreateForm
+from django.urls import reverse_lazy, reverse
+from django.views.generic import CreateView, DetailView, UpdateView
+from albums.forms import AlbumCreateForm, AlbumEditForm
+from albums.mixins import AttachOwnerMixin
 from albums.models import Album
 from profiles.util import get_profile
 
 
-class AlbumCreateView(CreateView):
+class AlbumCreateView(AttachOwnerMixin, CreateView):
     model = Album
     form_class = AlbumCreateForm
     success_url = reverse_lazy("profiles:home")
     template_name = 'albums/album-add.html'
 
-    def get_initial(self) -> dict:
-        initial = super().get_initial()
-        initial["owner"] = get_profile()
-        return initial
 
-    def form_valid(self, form):
-        form.instance.owner = get_profile()
-        return super().form_valid(form)
+class AlbumDetailView(DetailView):
+    model = Album
+    template_name = 'albums/album-details.html'
+
+
+class AlbumEditView(AttachOwnerMixin, UpdateView):
+    model = Album
+    form_class = AlbumEditForm
+    template_name = 'albums/album-edit.html'
+
+    def get_success_url(self) -> str:
+        return reverse('albums:detail', kwargs={'pk': self.object.pk})

--- a/musicApp/albums/views.py
+++ b/musicApp/albums/views.py
@@ -1,3 +1,21 @@
-from django.shortcuts import render
+from django.urls import reverse_lazy
+from django.views.generic import CreateView
+from albums.forms import AlbumCreateForm
+from albums.models import Album
+from profiles.util import get_profile
 
-# Create your views here.
+
+class AlbumCreateView(CreateView):
+    model = Album
+    form_class = AlbumCreateForm
+    success_url = reverse_lazy("profiles:home")
+    template_name = 'albums/album-add.html'
+
+    def get_initial(self) -> dict:
+        initial = super().get_initial()
+        initial["owner"] = get_profile()
+        return initial
+
+    def form_valid(self, form):
+        form.instance.owner = get_profile()
+        return super().form_valid(form)

--- a/musicApp/musicApp/urls.py
+++ b/musicApp/musicApp/urls.py
@@ -20,4 +20,5 @@ from django.urls import path, include
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('profiles.urls')),
+    path('albums/', include('albums.urls')),
 ]

--- a/musicApp/templates/albums/album-add.html
+++ b/musicApp/templates/albums/album-add.html
@@ -2,39 +2,12 @@
 
 {% block content %}
 <section class="createPage">
-<form>
+<form method="post">
   <fieldset>
     <legend>Add Album</legend>
     <div class="container">
-      <!-- Form for Adding Album -->
-      <label for="name">Album Name:</label>
-      <input id="name" type="text" placeholder="Album Name" required />
-
-      <label for="artist">Artist:</label>
-      <input id="artist" type="text" placeholder="Artist" required />
-
-      <label for="genre">Genre:</label>
-      <select id="genre" name="genre">
-        <option value="1">-------</option>
-        <option value="2">Pop Music</option>
-        <option value="3">Jazz Music</option>
-        <option value="4">R&B Music</option>
-        <option value="5">Rock Music</option>
-        <option value="6">Country Music</option>
-        <option value="7">Dance Music</option>
-        <option value="8">Hip Hop Music</option>
-        <option value="9">Other</option>
-      </select>
-
-      <label for="description">Description:</label>
-      <textarea id="description" placeholder="Description"></textarea>
-
-      <label for="imgUrl">Image URL:</label>
-      <input id="imgUrl" type="url" placeholder="Image URL" required />
-
-      <label for="price">Price:</label>
-      <input id="price" type="number" placeholder="Price" required />
-
+      {{ form }}
+      {% csrf_token %}
       <!-- Button for Adding Album -->
       <button class="add-album" type="submit">Add New Album</button>
     </div>

--- a/musicApp/templates/albums/album-delete.html
+++ b/musicApp/templates/albums/album-delete.html
@@ -2,72 +2,12 @@
 
 {% block content %}
 <section class="editPage">
-<form>
+<form method="post">
   <fieldset>
     <legend>Delete Album</legend>
     <div class="container">
-      <!-- Form for Deleting an Album -->
-      <label for="name">Album Name:</label>
-      <input
-        id="name"
-        name="name"
-        class="name"
-        type="text"
-        value="In These Silent Days"
-        disabled=""
-        readonly
-      />
-
-      <label for="artist">Artist:</label>
-      <input
-        id="artist"
-        name="artist"
-        class="artist"
-        type="text"
-        value="Brandi Carlile"
-        disabled=""
-        readonly
-      />
-
-      <label for="genre">Genre:</label>
-      <select id="genre" name="genre">
-        <option value="other">Other</option>
-      </select>
-
-      <label for="description">Description:</label>
-      <textarea
-        id="description"
-        name="description"
-        class="description"
-        rows="10"
-        cols="10"
-        disabled=""
-        readonly
-      >
-Upon release, In These Silent Days received positive reviews from critics. At Metacritic, which assigns a normalized rating out of 100 to reviews from mainstream critics, the album has an average score of 87 out of 100, which indicates 'universal acclaim'.</textarea
-      >
-
-      <label for="imgUrl">Image URL:</label>
-      <input
-        id="imgUrl"
-        name="imgUrl"
-        class="imgUrl"
-        type="url"
-        value="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F6%2F2021%2F07%2F20%2FBrandiCarlile-AlbumCover-Web.jpg"
-        disabled
-        readonly
-      />
-
-      <label for="price">Price:</label>
-      <input
-        id="price"
-        name="price"
-        class="price"
-        type="number"
-        value="12.8"
-        disabled=""
-        readonly
-      />
+      {{ form }}
+      {% csrf_token %}
 
       <!-- Button for Deleting an Album -->
       <button class="delete-album" type="submit">Delete Album</button>

--- a/musicApp/templates/albums/album-details.html
+++ b/musicApp/templates/albums/album-details.html
@@ -23,7 +23,7 @@
     <div class="actionBtn">
       <!-- Album Buttons -->
       <a href="{% url 'albums:edit' album.pk %}" class="edit">Edit</a>
-      <a href="#" class="remove">Delete</a>
+      <a href="{% url 'albums:delete' album.pk %}" class="remove">Delete</a>
     </div>
   </div>
 </div>

--- a/musicApp/templates/albums/album-details.html
+++ b/musicApp/templates/albums/album-details.html
@@ -5,26 +5,24 @@
 <div class="wrapper">
   <div class="albumCover">
     <!-- Album Image -->
-    <img src="/images/Lorde.jpg" alt="Cover Image" />
+    <img src="{{ album.image_url }}" alt="Cover Image" />
   </div>
 
   <div class="albumInfo">
     <div class="albumText">
       <!-- Album Info -->
-      <h1>Name: Melodrama</h1>
-      <h3>Artist: Lorde</h3>
-      <h4>Genre: Pop Music</h4>
-      <h4>Price: $7.33</h4>
+      <h1>Name: {{ album.album_name }}</h1>
+      <h3>Artist: {{ album.artist }}</h3>
+      <h4>Genre: {{ album.genre }}</h4>
+      <h4>Price: ${{ album.price|floatformat:2 }}</h4>
       <p>
-        Description: Melodrama is the second studio album by New Zealand
-        singer-songwriter Lorde. It was released on 16 June 2017 by Lava
-        and Republic Records and distributed through Universal.
+        Description: {{ album.description }}
       </p>
     </div>
 
     <div class="actionBtn">
       <!-- Album Buttons -->
-      <a href="#" class="edit">Edit</a>
+      <a href="{% url 'albums:edit' album.pk %}" class="edit">Edit</a>
       <a href="#" class="remove">Delete</a>
     </div>
   </div>

--- a/musicApp/templates/albums/album-edit.html
+++ b/musicApp/templates/albums/album-edit.html
@@ -1,105 +1,17 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <title>My Music App</title>
-    <!-- Static Load -->
-    <link rel="stylesheet" href="/css/style.css" />
-  </head>
+{% extends 'base.html' %}
 
-  <body>
-    <div id="box">
-      <!-- Navigation Bar -->
-      <header>
-        <nav>
-          <img src="/images/headphones.png" alt="headphones" />
-          <a href="#">Home</a>
-          <ul></ul>
-          <ul>
-            <!--Only for user with created profile-->
-            <li><a href="#">Create Album</a></li>
-            <li><a href="#">Profile</a></li>
-          </ul>
-        </nav>
-      </header>
-      <!-- End Navigation Bar -->
-
-      <!-- Main Content -->
-      <!--Edit Page-->
+{% block content %}
       <section class="editPage">
-        <form>
+        <form method="post">
           <fieldset>
             <legend>Edit Album</legend>
             <div class="container">
-              <!-- Form for Editing Album -->
-              <label for="name">Album Name:</label>
-              <input
-                id="name"
-                name="name"
-                class="name"
-                type="text"
-                value="In These Silent Days"
-              />
-
-              <label for="artist">Artist:</label>
-              <input
-                id="artist"
-                name="artist"
-                class="artist"
-                type="text"
-                value="Brandi Carlile"
-              />
-
-              <label for="genre">Genre:</label>
-              <input
-                id="genre"
-                name="genre"
-                class="genre"
-                type="text"
-                value="Other"
-              />
-
-              <label for="description">Description:</label>
-              <textarea
-                id="description"
-                name="description"
-                class="description"
-                rows="10"
-                cols="10"
-              >
-Upon release, In These Silent Days received positive reviews from critics. At Metacritic, which assigns a normalized rating out of 100 to reviews from mainstream critics, the album has an average score of 87 out of 100, which indicates 'universal acclaim'.</textarea
-              >
-
-              <label for="imgUrl">Image URL:</label>
-              <input
-                id="imgUrl"
-                name="imgUrl"
-                class="imgUrl"
-                type="text"
-                value="https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F6%2F2021%2F07%2F20%2FBrandiCarlile-AlbumCover-Web.jpg"
-              />
-
-              <label for="price">Price:</label>
-              <input
-                id="price"
-                name="price"
-                class="price"
-                type="text"
-                value="12.8"
-              />
-
+              {{ form }}
+              {% csrf_token %}
               <!-- Button for Editing Album -->
               <button class="edit-album" type="submit">Edit Album</button>
             </div>
           </fieldset>
         </form>
       </section>
-
-      <!-- Footer -->
-      <footer>
-        <div>&copy;SoftUni Team. All rights reserved.</div>
-      </footer>
-      <!-- End Footer -->
-    </div>
-  </body>
-</html>
+{% endblock %}

--- a/musicApp/templates/common/nav.html
+++ b/musicApp/templates/common/nav.html
@@ -7,7 +7,7 @@
   <ul></ul>
   <ul>
     <!--Only for user with created profile-->
-    <li><a href="#">Create Album</a></li>
+    <li><a href="{% url 'albums:create' %}">Create Album</a></li>
     <li><a href="{% url 'profiles:detail' %}">Profile</a></li>
   </ul>
 </nav>

--- a/musicApp/templates/profiles/home-with-profile.html
+++ b/musicApp/templates/profiles/home-with-profile.html
@@ -20,7 +20,7 @@
           <p class="price">Price: ${{ album.price|floatformat:2 }}</p>
         </div>
         <div class="btn-group">
-          <a href="#">Details</a>
+          <a href="{% url 'albums:detail' album.pk %}">Details</a>
         </div>
       </div>
     </div>

--- a/musicApp/templates/profiles/home-with-profile.html
+++ b/musicApp/templates/profiles/home-with-profile.html
@@ -2,60 +2,30 @@
 
 {% block content %}
 <section id="catalogPage">
-<!--  If No albums in catalog -->
-<p>No Albums in Catalog!</p>
 
-<!-- If albums in catalog -->
-<h1>All Albums</h1>
-<!-- First Card-Box in catalog -->
-<div class="card-box">
-  <img src="/images/BrandiCarlile.png" alt="Cover Image" />
-  <div>
-    <div class="text-center">
-      <p class="name">Name: In These Silent Days</p>
-      <p class="artist">Artist: Brandi Carlile</p>
-      <p class="genre">Genre: Other</p>
-      <p class="price">Price: $12.80</p>
-    </div>
-    <div class="btn-group">
-      <a href="#">Details</a>
-    </div>
-  </div>
-</div>
-<!-- End First Card-Box in catalog -->
+{% if albums %}
+    <h1>All Albums</h1>
+{% else %}
+    <p>No albums</p>
+{% endif %}
 
-<!-- Second Card-Box in catalog -->
-<div class="card-box">
-  <img src="/images/pinkFloyd.jpg" />
-  <div>
-    <div class="text-center">
-      <p class="name">Name: The Dark Side of the Moon</p>
-      <p class="artist">Artist: Pink Floyd</p>
-      <p class="genre">Genre: Rock Music</p>
-      <p class="price">Price: $28.75</p>
+{% for album in albums %}
+    <div class="card-box">
+      <img src="{{ album.image_url }}" alt="Cover Image" />
+      <div>
+        <div class="text-center">
+          <p class="name">Name: {{ album.album_name }}</p>
+          <p class="artist">Artist: {{ album.artist }}</p>
+          <p class="genre">Genre: {{ album.genre }}</p>
+          <p class="price">Price: ${{ album.price|floatformat:2 }}</p>
+        </div>
+        <div class="btn-group">
+          <a href="#">Details</a>
+        </div>
+      </div>
     </div>
-    <div class="btn-group">
-      <a href="#">Details</a>
-    </div>
-  </div>
-</div>
-<!-- End Second Card-Box in catalog -->
+{% empty %}
 
-<!-- Third Card-Box in catalog -->
-<div class="card-box">
-  <img src="/images/Lorde.jpg" />
-  <div>
-    <div class="text-center">
-      <p class="name">Name: Melodrama</p>
-      <p class="artist">Artist: Lorde</p>
-      <p class="genre">Genre: Pop Music</p>
-      <p class="price">Price: $7.33</p>
-    </div>
-    <div class="btn-group">
-      <a href="#">Details</a>
-    </div>
-  </div>
-</div>
-<!-- End Third Card-Box in catalog -->
+{% endfor %}
 </section>
 {% endblock %}


### PR DESCRIPTION
This pull request introduces full CRUD (Create, Read, Update, Delete) functionality for albums in the music app, refactoring the codebase to use Django's class-based views, forms, and templates. It also improves the user interface by dynamically rendering album data and updating navigation and catalog pages to use real album information.

**Backend: Album CRUD functionality and owner association**
* Added Django class-based views for creating, viewing, editing, and deleting albums in `albums/views.py`, utilizing custom forms and an `AttachOwnerMixin` to automatically associate albums with the current user (`owner`). [[1]](diffhunk://#diff-93904bde7dfb31c6e37533eb81e6d7d55ef50bf3f70d751c623d6f920e8c0af8L1-R40) [[2]](diffhunk://#diff-a166628f9ae72eb99715ccf34870e6a4034dd587bb0f25463ba65a7a5f7c3ac2R1-R12)
* Implemented model forms in `albums/forms.py` for album creation, editing, and deletion, including custom widgets and read-only/disabled fields for the delete form.
* Registered new album-related URL patterns in `albums/urls.py` and included them in the main project URLs to enable routing for album operations. [[1]](diffhunk://#diff-cecc03c7ad26dea3969600a4b92c641c0d1179fe2911d07654fee4adcb4c11deR1-R12) [[2]](diffhunk://#diff-c7f443ee19cc438102b3d9369196f3b1e48e6bde4315f950907e86618634cb9cR23)

**Frontend: Dynamic templates and navigation**
* Refactored album-related templates (`album-add.html`, `album-edit.html`, `album-delete.html`, `album-details.html`) to use Django forms and context variables, replacing hardcoded values with dynamic album data and adding CSRF protection. [[1]](diffhunk://#diff-e118219b1a40361d22c773716de1487d1f185c26fb732561d9ce24bf49333fcbL5-R10) [[2]](diffhunk://#diff-f83e9876962de42b42c5daf37557dcecb9bc818d1b5ee55a79248a0ab695b367L1-R17) [[3]](diffhunk://#diff-3077e88af1dc65d84872a8dd96637a534efc545702e7f9c0c1413cd9888ae71bL5-R10) [[4]](diffhunk://#diff-14b523d5f03e0c749dbfacff30bc2eb7c2c8ee8bd842ae8bfc5c518e51f3bfdfL8-R26)
* Updated the navigation bar and home/profile catalog page to link to the new album views and display real album information, including cover images and details. [[1]](diffhunk://#diff-2b9fe533fd49c86215f13719895793091b9604c22e54e8d03ee6d1aa7664a167L10-R10) [[2]](diffhunk://#diff-cd84305b283c325c3f83babfda80727c84d79ab47294892773ba4923c3212cc6L5-R29)